### PR TITLE
Fix github.com speedtest url

### DIFF
--- a/speedtest.html
+++ b/speedtest.html
@@ -3,8 +3,8 @@
     <script type='text/javascript'>
     var tests = {
       "github.com": {
-        "URI":    "https://github.com/images/modules/integrations/screens/pivotaltracker@2x.jpg",
-        "bytes":  572150
+        "URI":    "https://github.com/images/modules/about/press-header.jpg",
+        "bytes":  1033109
       },
       "githubusercontent.com": {
         "URI":    "https://cloud.githubusercontent.com/assets/47/5653388/9c6339cc-966e-11e4-8e8d-f7da87512a90.png",


### PR DESCRIPTION
`images/modules/integrations/screens/pivotaltracker@2x.jpg` was removed about a month and a half ago and this test is currently erroring out.

I replaced it with the largest file I could find in `public/` to try and minimise the impact latency has on the speed test.

cc @jnewland
